### PR TITLE
fix(sast): scope curl-pipe-shell off the declarative check corpus

### DIFF
--- a/.sscsb/rules/sscsb-default.yaml
+++ b/.sscsb/rules/sscsb-default.yaml
@@ -15,6 +15,14 @@ rules:
           - pattern-regex: 'wget[^|;\n]*\|\s*(sudo\s+)?(ba|z|da)?sh'
     paths:
       include: ["*.sh", "*.bash", "*.zsh", "Makefile", "*.yml", "*.yaml"]
+      # checks/ holds declarative .check.yaml data interpreted by
+      # src/check/interpreter.rs (HTTP + CEL — no field ever reaches a shell),
+      # and its description prose legitimately NAMES attacks like `curl | sh`
+      # when documenting what a control defends against. A match there is false
+      # by construction — same rationale as the workflow's .sscsb/rules
+      # exclusion — while every executable surface stays covered. Broke the
+      # ona PR (run 32213773362) on exactly such prose.
+      exclude: ["checks/**"]
 
   - id: sscsb.git-protocol-insecure
     languages: [generic]


### PR DESCRIPTION
## Summary

Closes the one still-open defect behind the Aug 10–19 CI red streak: the `sscsb.curl-pipe-shell` ERROR rule (generic-language regex over `*.yml`/`*.yaml`) matches **prose** inside declarative `checks/**` YAML. It broke the ona PR (run 32213773362) on ONA-2.02's description sentence naming the `curl | sh` attack the check defends against; that PR got green only by rewording the prose, which left the class open — any future check description that literally names the attack re-breaks CI.

Fix: add `exclude: ["checks/**"]` to the rule's paths. Check YAMLs are data interpreted by `src/check/interpreter.rs` (HTTP + CEL — no field ever reaches a shell), so a match there is false by construction; this mirrors the workflow's existing `--exclude .sscsb/rules` and the npm rule's comment-guard precedent. Every executable surface (`*.sh`, `*.bash`, `*.zsh`, `Makefile`, workflow/CI YAML) keeps full coverage, `--error` gating stays, and no true finding is suppressed.

Verified with semgrep 1.175.0 against the edited ruleset: ONA-2.02 prose → 0 findings; a real `curl … | sh` in a `.sh` fixture → still flagged; a real `curl … | bash` in a workflow `.yml` outside `checks/` → still flagged; whole-repo ERROR count under the workflow's own excludes → 0.

For context, the rest of that red streak was already fixed on main by PR #20 / commit 3720145 (gitleaks license gate → pinned OSS binary; RUSTSEC-2024-0436 `paste` → `cel` 0.14; fuzz.yml's missing `../grc-controls` sibling checkout; the 14 pre-existing Semgrep findings → loaders hardening) — nothing further needed there. One structural item is left as an owner decision, not changed here: Dependabot's cargo security-update jobs have failed since 2026-03-13 because `Cargo.toml`'s `../grc-controls` path deps can't resolve in Dependabot's isolated clone; fixing it properly means pinned git deps + granting Dependabot access to the private repo + reworking the 10 CI sibling-checkout steps, which touches credentials and org settings.

## AI Provenance Declaration

- [x] AI generated or assisted with **code** in this PR
- [ ] AI generated or assisted with **tests** in this PR
- [ ] AI introduced or suggested **new dependencies** in this PR
- [ ] AI generated or assisted with **documentation** in this PR

**AI tool(s)/model(s) used (if any):** Claude Code

**Human review performed on AI-generated parts (what/how):** None yet — this draft PR is the review vehicle. The rule-scope change was validated empirically with semgrep before/after (details above).

## Dependency Changes

- [x] No new dependencies
- [ ] New dependencies validated (`sscsb deps check`) and approved

## Merge Policy Reminder

AI involvement is declared above, so the merge to `main` needs an approved human hardware-backed key and review evidence (`Reviewed-by:` trailer). See `docs/signing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qAUyZgpei6EhKL6jXdu1C

---
_Generated by [Claude Code](https://claude.ai/code/session_016qAUyZgpei6EhKL6jXdu1C)_